### PR TITLE
Potential fix for code scanning alert no. 4: Uncontrolled data used in path expression

### DIFF
--- a/restaurant/src/main/java/ku/cs/restaurant/service/ImageService.java
+++ b/restaurant/src/main/java/ku/cs/restaurant/service/ImageService.java
@@ -14,8 +14,18 @@ public class ImageService {
     public String saveImage(String folderPath, MultipartFile image) throws IOException {
         Files.createDirectories(Paths.get(folderPath));
         String fileName = System.currentTimeMillis() + "_" + image.getOriginalFilename();
-        Path path = Paths.get(folderPath, fileName);
+        validateFileName(fileName);
+        Path path = Paths.get(folderPath, fileName).normalize();
+        if (!path.startsWith(Paths.get(folderPath).normalize())) {
+            throw new IllegalArgumentException("Invalid file path");
+        }
         Files.copy(image.getInputStream(), path, StandardCopyOption.REPLACE_EXISTING);
         return path.toString();
+    }
+
+    private void validateFileName(String fileName) {
+        if (fileName.contains("..") || fileName.contains("/") || fileName.contains("\\")) {
+            throw new IllegalArgumentException("Invalid filename");
+        }
     }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/chokunlim/472-G-FOODMAN-MosFoodwork/security/code-scanning/4](https://github.com/chokunlim/472-G-FOODMAN-MosFoodwork/security/code-scanning/4)

To fix the problem, we need to validate the filename obtained from the `MultipartFile` to ensure it does not contain any path traversal characters or sequences. This can be done by checking for the presence of "..", "/", or "\\" in the filename and rejecting the input if any are found. Additionally, we should normalize the path to ensure it stays within the intended directory.

1. Add a method to validate the filename.
2. Use this method in the `saveImage` function to check the filename before constructing the path.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
